### PR TITLE
Add Zed Location for NixOS

### DIFF
--- a/Editor/ZedDiscovery.cs
+++ b/Editor/ZedDiscovery.cs
@@ -24,6 +24,9 @@ namespace UnityZed
                 // [Linux] (Repo) 
                 ("/usr/bin/zeditor", null),
 
+                // [Linux] (NixOS)
+                ("/run/current-system/sw/bin/zeditor", null),
+
                 // [Linux] (Official Website)
                 (NPath.HomeDirectory.Combine(".local/bin/zed"), null),
             };


### PR DESCRIPTION
Makes it work on NixOS as it follows non standard path conventions.