### PR TITLE
fix: replace modern C# syntax for compatibility with older versions

### DIFF
--- a/Editor/NiceIO.cs
+++ b/Editor/NiceIO.cs
@@ -1806,7 +1806,7 @@ namespace NiceIO
                                 File_Delete(file);
                             }
                             // Another process/thread may have deleted (or be in the process of deleting) the file since the time we listed out the directory, causing any of these exceptions.
-                            catch (Exception e) when (e is InvalidOperationException or FileNotFoundException or UnauthorizedAccessException)
+                            catch (Exception e) when (e is InvalidOperationException || e is FileNotFoundException || e is UnauthorizedAccessException)
                             {
                                 if (file.FileExists())
                                     throw;

--- a/Editor/ZedDiscovery.cs
+++ b/Editor/ZedDiscovery.cs
@@ -47,7 +47,7 @@ namespace UnityZed
                     if (candidateTryGetVersion(candidatePath, out var version))
                         name.Append($" [{version}]");
 
-                    results.Add(new()
+                    results.Add(new CodeEditor.Installation()
                     {
                         Name = name.ToString(),
                         Path = candidatePath.MakeAbsolute().ToString(),

--- a/Editor/ZedExternalCodeEditor.cs
+++ b/Editor/ZedExternalCodeEditor.cs
@@ -22,7 +22,7 @@ namespace UnityZed
         }
 
         private static readonly ILogger sLogger = ZedLogger.Create();
-        private static readonly ZedDiscovery sDiscovery = new();
+        private static readonly ZedDiscovery sDiscovery = new ZedDiscovery();
 
         private ZedProcess m_Process;
         private ZedPreferences m_Preferences;
@@ -31,10 +31,10 @@ namespace UnityZed
 
         public void Initialize(string editorInstallationPath)
         {
-            m_Process = new(editorInstallationPath);
+            m_Process = new ZedProcess(editorInstallationPath);
             m_Generator = CreateSdkStyleGeneration();
-            m_Preferences = new(m_Generator);
-            m_Settings = new();
+            m_Preferences = new ZedPreferences(m_Generator);
+            m_Settings = new ZedSettings();
         }
 
         //

--- a/Editor/ZedPreferences.cs
+++ b/Editor/ZedPreferences.cs
@@ -36,7 +36,9 @@ namespace UnityZed
             SettingsButton(ProjectGenerationFlag.Registry, "Registry packages", "", m_Generator);
             SettingsButton(ProjectGenerationFlag.Git, "Git packages", "", m_Generator);
             SettingsButton(ProjectGenerationFlag.BuiltIn, "Built-in packages", "", m_Generator);
+#if UNITY_2019_3_OR_NEWER
             SettingsButton(ProjectGenerationFlag.LocalTarBall, "Local tarball", "", m_Generator);
+#endif
             SettingsButton(ProjectGenerationFlag.Unknown, "Packages from unknown sources", "", m_Generator);
             SettingsButton(ProjectGenerationFlag.PlayerAssemblies, "Player projects", "For each player project generate an additional csproj with the name 'project-player.csproj'", m_Generator);
             RegenerateProjectFiles(m_Generator);


### PR DESCRIPTION
### Summary

This PR updates the code to ensure compatibility with older versions of Unity that use C# 7.3.

### Changes made
- Replaced exception filters using `or` pattern with `||`, which is supported in C# 7.3.
- Replaced target-typed `new()` instantiations with explicit type names.

These changes allow the package to compile and run correctly on Unity versions that do not support newer C# syntax features.

### Testing

Tested successfully in Unity 2019.4.28f1 — the package now builds and runs without errors.